### PR TITLE
fix – build warnings for next/link in header.tsx and footer.tsx

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -67,7 +67,10 @@ function Footer({ copyrightHolder = 'Company Name' }: Props): JSX.Element {
 
           <p className="text-white small">The University of Tennessee<br />Knoxville, Tennessee 37996<br />865-974-1000</p>
           <p className="text-white small">The flagship campus of the <a href="https://tennessee.edu/" target="_blank" rel="noreferrer" className="text-white footer-links">University of Tennessee System</a> and partner in the <a href="https://www.tntransferpathway.org/" target="_blank" rel="noreferrer" className="text-white footer-links">Tennessee Transfer Pathway</a>.</p>
-          <p className="text-white small"><a className="text-white me-3 footer-links" href="https://oed.utk.edu/ada/">ADA</a> <a className="text-white me-3 footer-links" href="/about/privacy/">Privacy</a> <a className="text-white me-3 footer-links" href="https://safety.utk.edu/">Safety</a> <a className="text-white footer-links" href="https://titleix.utk.edu/">Title&nbsp;IX</a>  </p>
+          <p className="text-white small"><a className="text-white me-3 footer-links" href="https://oed.utk.edu/ada/">ADA</a> 
+          <Link href="/about/privacy/">
+          <a className="text-white me-3 footer-links" >Privacy</a>
+          </Link> <a className="text-white me-3 footer-links" href="https://safety.utk.edu/">Safety</a> <a className="text-white footer-links" href="https://titleix.utk.edu/">Title&nbsp;IX</a>  </p>
         </div>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,9 +40,11 @@ function Header({
         <div className="container-xxl">
           <div className="row justify-content-between py-3 py-md-4 py-lg-0">
       <div className="col-5 col-sm-6 col-md-6 col-lg-2 col-xl-3 align-items-center">
-          <a href="/" className="d-grid h-100 mt-lg-2">
+         <Link href="/" >
+           <a className="d-grid h-100 mt-lg-2">
             <img src="/images/chrome/logo-horizontal-left-smokey.svg" alt="University of Tennessee, Knoxville" />
-          </a>
+            </a>
+          </Link>
       </div>
 
       <button className="navbar-toggler col-auto mr-auto" type="button" id="mobile-menu-open" data-toggle="#site-navigation"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M24 6h-24v-4h24v4zm0 4h-24v4h24v-4zm0 8h-24v4h24v-4z"></path></svg><span className="visually-hidden">Menu</span></button>
@@ -123,9 +125,13 @@ function Header({
             <span aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" className="bi bi-info-circle mb-1" viewBox="0 0 16 16">
             <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
             <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
-          </svg></span> <a href="/coronavirus/" className="text-center text-decoration-none text-reset home-covid-banner">COVID-19 Information and Support <span aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" className="bi bi-chevron-right mb-1" viewBox="0 0 16 16">
+          </svg></span> 
+          <Link href="/coronavirus/">
+          <a className="text-center text-decoration-none text-reset home-covid-banner">COVID-19 Information and Support <span aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" className="bi bi-chevron-right mb-1" viewBox="0 0 16 16">
             <path fillRule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
           </svg></span></a>
+          </Link>
+
           </div>
           </div>
           <div className="modal fade" id="searchModal" tabIndex={-1}  aria-hidden="true">


### PR DESCRIPTION
Fix Build Errors pertaining to next/link:

**./src/components/Header.tsx**

- 43:11  Warning: Do not use the HTML <a> tag to navigate to /. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages  @next/next/no-html-link-for-pages
- 126:25  Warning: Do not use the HTML <a> tag to navigate to /coronavirus/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages  @next/next/no-html-link-for-pages

**./src/components/Footer.tsx**

- 70:127  Warning: Do not use the HTML <a> tag to navigate to /about/privacy/. Use Link from 'next/link' instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages  @next/next/no-html-link-for-pages