### PR TITLE
Refactor as needed to get app building again

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,12 +11,14 @@ function Footer({ copyrightHolder = 'Company Name' }: Props): JSX.Element {
   const year = new Date().getFullYear();
 
   const { menuItems } = client.useQuery();
-  const tools = menuItems({
-    where: { location: MenuLocationEnum.TOOLS },
-  }).nodes;
-  const links = menuItems({
-    where: { location: MenuLocationEnum.LINKS },
-  }).nodes;
+  const tools =
+    menuItems({
+      where: { location: MenuLocationEnum.TOOLS },
+    })?.nodes || [];
+  const links =
+    menuItems({
+      where: { location: MenuLocationEnum.LINKS },
+    })?.nodes || [];
 
   return (
     <footer id="colophon" className="site-footer  mt-auto">
@@ -29,35 +31,45 @@ function Footer({ copyrightHolder = 'Company Name' }: Props): JSX.Element {
                   <div className="col-6">
                     <h4 className="text-white">Tools</h4>
                     <ul id="list-unstyled" className="list-unstyled">
-                      {tools?.map((tool) => (
-                        <li key={`${tool.label}$-menu`}>
-                          <Link href={tool.url ?? ''}>
-                            <a
-                              className="text-white footer-links"
-                              href={tool.url}
-                            >
-                              {tool.label}
-                            </a>
-                          </Link>
-                        </li>
-                      ))}
+                      {tools.flatMap((tool) => {
+                        const label = tool?.label;
+                        const url = tool?.url;
+                        if (label && url) {
+                          return (
+                            <li key={`${label}$-menu`}>
+                              <Link href={url}>
+                                <a className="text-white footer-links">
+                                  {label}
+                                </a>
+                              </Link>
+                            </li>
+                          );
+                        } else {
+                          return [];
+                        }
+                      })}
                     </ul>
                   </div>
                   <div className="col-6">
                     <h4 className="text-white">Campus Links</h4>
                     <ul className="list-unstyled">
-                      {links?.map((link) => (
-                        <li key={`${link.label}$-menu`}>
-                          <Link href={link.url ?? ''}>
-                            <a
-                              className="text-white footer-links"
-                              href={link.url}
-                            >
-                              {link.label}
-                            </a>
-                          </Link>
-                        </li>
-                      ))}
+                      {links.flatMap((link) => {
+                        const label = link?.label;
+                        const url = link?.url;
+                        if (label && url) {
+                          return (
+                            <li key={`${label}$-menu`}>
+                              <Link href={url}>
+                                <a className="text-white footer-links">
+                                  {label}
+                                </a>
+                              </Link>
+                            </li>
+                          );
+                        } else {
+                          return [];
+                        }
+                      })}
                     </ul>
                   </div>
                 </div>
@@ -120,12 +132,14 @@ function Footer({ copyrightHolder = 'Company Name' }: Props): JSX.Element {
             </div>
 
             <div className="utk-identifier col-12 col-md-5 col-lg-4 ms-lg-auto mt-md-n5 p-4">
-              <a className="mb-4 d-block" href="/">
-                <img
-                  src="/images/chrome/logo-horizontal-left-white.svg"
-                  alt="University of Tennessee, Knoxville"
-                />
-              </a>
+              <Link href="/">
+                <a className="mb-4 d-block">
+                  <img
+                    src="/images/chrome/logo-horizontal-left-white.svg"
+                    alt="University of Tennessee, Knoxville"
+                  />
+                </a>
+              </Link>
 
               <p className="text-white small">
                 The University of Tennessee
@@ -183,9 +197,11 @@ function Footer({ copyrightHolder = 'Company Name' }: Props): JSX.Element {
         </div>
       </div>
 
+      {/* might just need to nix this script and "redo" functionality in the React way */}
       <script
         src="//images.utk.edu/designsystem/v1/0.0.9/assets/js/utk.js"
         id="utk-bootstrap-designsytemscripts-js"
+        defer
       ></script>
       <script
         async

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,8 @@
 import Header from './Header';
 import Footer from './Footer';
+import { ReactNode } from 'react';
 
-export default function Layout({ children }) {
+export default function Layout({ children }: { children: ReactNode }) {
   return (
     <>
       <Header />

--- a/src/components/Posts.tsx
+++ b/src/components/Posts.tsx
@@ -37,7 +37,7 @@ function Posts({
         )}
         {intro && <p className={styles.intro}>{intro}</p>}
         <div className="row row-cols-1 row-cols-md-2 row-cols-lg-3  row-cols-xl-4 g-4">
-          {posts.map((post) => (
+          {posts?.map((post) => (
             <div className="col" key={post.id ?? ''}>
               <div
                 className="card card-body"
@@ -46,8 +46,10 @@ function Posts({
               >
                 <div>
                   <ImageCap
-                    title={post?.featuredImage?.node?.title()}
-                    bgImage={post?.featuredImage?.node?.sourceUrl()}
+                    title={post?.featuredImage?.node?.title() || ''}
+                    bgImage={
+                      post?.featuredImage?.node?.sourceUrl() || undefined
+                    }
                   />
                   <Heading level={postTitleLevel} className={styles.title}>
                     <Link href={`/posts/${post.slug}`}>

--- a/src/components/Sprite.tsx
+++ b/src/components/Sprite.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+// import ReactDOM from 'react-dom';
 
-// keep a list of the icon ids we put in the symbol
-const icons = ['utk-logo-white', 'icon-2'];
+// // keep a list of the icon ids we put in the symbol
+// const icons = ['utk-logo-white', 'icon-2'];
 
-// then define an Icon component that references the
-function Icon({ id, ...props }) {
-  return (
-    <svg {...props}>
-      <use href={`/sprite.svg#${id}`} />
-    </svg>
-  );
-}
+// // then define an Icon component that references the
+// function Icon({ id, ...props }) {
+//   return (
+//     <svg {...props}>
+//       <use href={`/sprite.svg#${id}`} />
+//     </svg>
+//   );
+// }
 
-// In your App, you can now render the icons
-function App() {
-  return (
-    <div className="App">
-      {icons.map((id) => {
-        return <Icon key={id} id={id} />;
-      })}
-    </div>
-  );
-}
+// // In your App, you can now render the icons
+// function App() {
+//   return (
+//     <div className="App">
+//       {icons.map((id) => {
+//         return <Icon key={id} id={id} />;
+//       })}
+//     </div>
+//   );
+// }
 
-const rootElement = document.getElementById('root');
-ReactDOM.render(<App />, rootElement);
+// const rootElement = document.getElementById('root');
+// ReactDOM.render(<App />, rootElement);

--- a/src/components/TaggedPage.tsx
+++ b/src/components/TaggedPage.tsx
@@ -1,30 +1,30 @@
 import React from 'react';
-import { client } from 'client';
+// import { client } from 'client';
 
-interface TaggedPageProps {
-  id;
-  contentType;
-  typeName;
-}
+// interface TaggedPageProps {
+//   id;
+//   contentType;
+//   typeName;
+// }
 
-export default function TaggedPage({
-  id,
-  contentType,
-  typeName,
-}: TaggedPageProps): JSX.Element {
-  const { useQuery } = client;
+// export default function TaggedPage({
+//   id,
+//   contentType,
+//   typeName,
+// }: TaggedPageProps): JSX.Element {
+//   const { useQuery } = client;
 
-  if (contentType === 'TimelineEvent') {
-    var contentCall = 'timelineEvent';
-  } else {
-    contentCall = contentType;
-  }
+//   if (contentType === 'TimelineEvent') {
+//     var contentCall = 'timelineEvent';
+//   } else {
+//     contentCall = contentType;
+//   }
 
-  var thisPage = useQuery()[contentCall]?.({ id: id });
+//   var thisPage = useQuery()[contentCall]?.({ id: id });
 
-  return (
-    <div>
-      <h3>{thisPage?.title()}</h3>
-    </div>
-  );
-}
+//   return (
+//     <div>
+//       <h3>{thisPage?.title()}</h3>
+//     </div>
+//   );
+// }

--- a/src/components/calEvent.tsx
+++ b/src/components/calEvent.tsx
@@ -1,29 +1,35 @@
 import React from 'react';
 
-const CalEvent = (props) => {
-  const [fetchedEvents, setEvents] = React.useState({ events: [] });
+interface Event {
+  id: number;
+  title: string;
+}
+
+const CalEvent = () => {
+  const [events, setEvents] = React.useState<Event[]>([]);
 
   React.useEffect(() => {
     const fetchCalEvents = async () => {
       const response = await fetch(
         'https://calendar.utk.edu/api/2/events?page=1&pp=5'
       );
-      const fetchedEvents = await response.json();
+      const { events: fetchedEvents }: { events: Event[] } =
+        await response.json();
       setEvents(fetchedEvents);
     };
     fetchCalEvents();
   }, []);
 
-  fetchedEvents?.events?.map((event) => console.log(event));
-
   return (
     <div>
       <h1>Event Titles</h1>
-      <ul>
-        {fetchedEvents?.events?.map((event) => (
-          <li key={event?.event.id}>{event?.event.title}</li>
-        ))}
-      </ul>
+      {events.length > 0 && (
+        <ul>
+          {events.map((event) => (
+            <li key={event.id}>{event.title}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+/*
+  Note:
+  To comply with https://github.com/vercel/next.js/pull/36772,
+  we've replaced `src/pages/_middleware.tsx` with this file.
+  Simply copy-pasted its contents, and I don't *think* there's
+  anything else we need to do in this case. For reference,
+  instructions are here: https://nextjs.org/docs/messages/nested-middleware#possible-ways-to-fix-it
+*/
+
 export function middleware(req: NextRequest) {
   // PRIMARY_DOMAIN should be a full URL including protocol, e.g. https://www.google.com
   const hasEnvVariable = !!process.env.PRIMARY_DOMAIN;
@@ -15,10 +24,10 @@ export function middleware(req: NextRequest) {
 
   //const url = req.nextUrl.clone();
   const url = req.nextUrl;
-  const normalizedHost = new URL(process.env.PRIMARY_DOMAIN);
+  const normalizedHost = new URL(process.env.PRIMARY_DOMAIN!);
   const host = req.headers.get('host');
 
-  const isCorrectHostname = host.split(':')[0] === normalizedHost.hostname;
+  const isCorrectHostname = host?.split(':')[0] === normalizedHost.hostname;
 
   if (!isCorrectHostname) {
     url.protocol = normalizedHost.protocol;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -9,8 +9,8 @@ export default function Page(): JSX.Element {
   return (
     <>
       <Header
-        title={generalSettings?.title}
-        description={generalSettings?.description}
+        title={generalSettings?.title || undefined}
+        description={generalSettings?.description || undefined}
       />
       <main className="content content-page">
         <PageTitle title={"Oops! That page can't be found."} />
@@ -25,7 +25,7 @@ export default function Page(): JSX.Element {
           </div>
         </div>
       </main>
-      <Footer copyrightHolder={generalSettings?.title} />
+      <Footer copyrightHolder={generalSettings?.title || undefined} />
     </>
   );
 }

--- a/src/pages/[...pageUri].tsx
+++ b/src/pages/[...pageUri].tsx
@@ -5,42 +5,42 @@ import Head from 'next/head';
 import { client, Page as PageType } from 'client';
 
 export interface PageProps {
-  page: PageType | PageType['preview']['node'] | null | undefined;
+  page: PageType | null | undefined;
 }
 
 export function PageComponent({ page }: PageProps) {
   const { useQuery } = client;
   const generalSettings = useQuery().generalSettings;
 
-  const pageSlug = page.slug;
+  const pageSlug = page?.slug;
   console.log('My custom identifier class is based on slug: ' + pageSlug);
 
   return (
     <>
       <Header
-        title={generalSettings.title}
-        description={generalSettings.description}
-        uri={page?.uri}
+        title={generalSettings?.title || undefined}
+        description={generalSettings?.description || undefined}
+        uri={page?.uri || undefined}
       />
 
       <Head>
         <title>
-          {page?.title()} - {generalSettings.title}
+          {page?.title()} - {generalSettings?.title}
         </title>
       </Head>
 
       <PageTitle
-        title={page?.title()}
-        bgImage={page?.featuredImage?.node.sourceUrl()}
+        title={page?.title() || ''}
+        bgImage={page?.featuredImage?.node?.sourceUrl() || undefined}
       />
-      <body className={pageSlug} />
+      <body className={pageSlug || ''} />
       <main className={'content content-single ' + pageSlug}>
         <div className="container-xxl pt-5">
           <div dangerouslySetInnerHTML={{ __html: page?.content() ?? '' }} />
         </div>
       </main>
 
-      <Footer copyrightHolder={generalSettings.title} />
+      <Footer copyrightHolder={generalSettings?.title || undefined} />
     </>
   );
 }

--- a/src/pages/alpha.tsx
+++ b/src/pages/alpha.tsx
@@ -5,6 +5,8 @@ import Script from 'next/script';
 import { client, PostObjectsConnectionOrderbyEnum, OrderEnum } from 'client';
 import { TRUE } from 'sass';
 
+const letters = 'abcdefghijklmnopqrstuvwxyz'.split('');
+
 function Alpha() {
   const Search = console.log('Search button will eventually do something');
 
@@ -22,12 +24,12 @@ function Alpha() {
     },
   });
 
-  function isLetter(this_letter) {
-    let aLetter = alphaIndex.nodes.map((this_alpha) => {
+  function isLetter(this_letter: string) {
+    let aLetter = alphaIndex?.nodes?.map((this_alpha) => {
       //console.log(this_letter);
       if (
         this_alpha
-          .title()
+          ?.title()
           ?.toString()
           ?.toLowerCase()
           ?.match('^' + this_letter)
@@ -36,7 +38,7 @@ function Alpha() {
       }
     });
 
-    return aLetter.includes(true);
+    return aLetter?.includes(true);
   }
 
   //console.log(isLetter([0-9]));
@@ -54,7 +56,7 @@ function Alpha() {
 
   return (
     <Layout>
-      <Head></Head>
+      {/* <Head></Head> */}
       <section className={styles['intro-container']}>
         <div className={styles['page-title-group']}>
           <hr className={styles['oa-thick-bar']} />
@@ -90,33 +92,14 @@ function Alpha() {
       </section>
       <section className={styles['alpha-container']}>
         <div className={styles.alpha}>
-          {isLetter('[0-9]') === true && <a href="#num">#</a>}
-          {isLetter('a') === true && <a href="#a">A</a>}
-          {isLetter('b') === true && <a href="#b">B</a>}
-          {isLetter('c') === true && <a href="#c">C</a>}
-          {isLetter('d') === true && <a href="#d">D</a>}
-          {isLetter('e') === true && <a href="#e">E</a>}
-          {isLetter('f') === true && <a href="#f">F</a>}
-          {isLetter('g') === true && <a href="#g">G</a>}
-          {isLetter('h') === true && <a href="#h">H</a>}
-          {isLetter('i') === true && <a href="#i">I</a>}
-          {isLetter('j') === true && <a href="#j">J</a>}
-          {isLetter('k') === true && <a href="#k">K</a>}
-          {isLetter('l') === true && <a href="#l">L</a>}
-          {isLetter('m') === true && <a href="#m">M</a>}
-          {isLetter('n') === true && <a href="#n">N</a>}
-          {isLetter('o') === true && <a href="#o">O</a>}
-          {isLetter('p') === true && <a href="#p">P</a>}
-          {isLetter('q') === true && <a href="#q">Q</a>}
-          {isLetter('r') === true && <a href="#r">R</a>}
-          {isLetter('s') === true && <a href="#s">S</a>}
-          {isLetter('t') === true && <a href="#t">T</a>}
-          {isLetter('u') === true && <a href="#u">U</a>}
-          {isLetter('v') === true && <a href="#v">V</a>}
-          {isLetter('w') === true && <a href="#w">W</a>}
-          {isLetter('x') === true && <a href="#x">X</a>}
-          {isLetter('y') === true && <a href="#y">Y</a>}
-          {isLetter('z') === true && <a href="#z">Z</a>}
+          {isLetter('[0-9]') && <a href="#num">#</a>}
+          {letters.flatMap((letter) =>
+            isLetter(letter) ? (
+              <a href={`#${letter}`}>{letter.toUpperCase()}</a>
+            ) : (
+              <></>
+            )
+          )}
         </div>
       </section>
       <section className={styles.results}>
@@ -157,808 +140,72 @@ function Alpha() {
               </h2>
             </div>
             <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
+              {alphaIndex?.nodes?.flatMap((this_alpha) => {
+                const url = this_alpha?.aToZFields?.url;
+                if (
+                  url &&
+                  this_alpha
                     ?.title()
                     ?.toString()
                     ?.toLowerCase()
-                    ?.match('^[0-9]') && (
+                    ?.match('^[0-9]')
+                ) {
+                  return (
                     <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
+                      <a href={url}>{this_alpha.title()}</a>
                       <br />
                       <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
+                        {url.replace(/^https?:\/\//, '')}
                       </span>
                     </li>
-                  )}
-                </>
-              ))}
+                  );
+                } else {
+                  return [];
+                }
+              })}
             </ul>
           </div>
         )}
-        {isLetter('a') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="a" className={styles.letter}>
-                A
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^a') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('b') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="b" className={styles.letter}>
-                B
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^b') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('c') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="c" className={styles.letter}>
-                C
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^c') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('d') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="d" className={styles.letter}>
-                D
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^d') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('e') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="e" className={styles.letter}>
-                E
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^e') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('f') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="f" className={styles.letter}>
-                F
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^f') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('g') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="g" className={styles.letter}>
-                G
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^g') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('h') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="h" className={styles.letter}>
-                H
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^h') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('i') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="i" className={styles.letter}>
-                I
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^i') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('j') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="j" className={styles.letter}>
-                J
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^j') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('k') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="k" className={styles.letter}>
-                K
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^k') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('l') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="l" className={styles.letter}>
-                L
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^l') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('m') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="m" className={styles.letter}>
-                M
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^m') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('n') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="n" className={styles.letter}>
-                N
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^n') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('o') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="o" className={styles.letter}>
-                O
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^o') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('p') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="p" className={styles.letter}>
-                P
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^p') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('q') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="q" className={styles.letter}>
-                Q
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^q') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('r') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="r" className={styles.letter}>
-                R
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^r') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('s') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="s" className={styles.letter}>
-                S
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^s') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('t') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="t" className={styles.letter}>
-                T
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^t') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('u') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="u" className={styles.letter}>
-                U
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^u') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('v') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="v" className={styles.letter}>
-                V
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^v') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('w') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="w" className={styles.letter}>
-                W
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^w') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('x') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="x" className={styles.letter}>
-                X
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^x') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('y') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="y" className={styles.letter}>
-                Y
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^y') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
-        {isLetter('z') === true && (
-          <div className={styles['letter-group']}>
-            <div className={styles['letter-container']}>
-              <h2 id="z" className={styles.letter}>
-                Z
-              </h2>
-            </div>
-            <ul>
-              {alphaIndex.nodes.map((this_alpha) => (
-                <>
-                  {this_alpha
-                    ?.title()
-                    ?.toString()
-                    ?.toLowerCase()
-                    ?.match('^z') && (
-                    <li className={styles['result-title']}>
-                      <a href={this_alpha.aToZFields.url}>
-                        {this_alpha.title()}
-                      </a>
-                      <br />
-                      <span className={styles['result-url']}>
-                        {this_alpha.aToZFields.url?.replace(/^https?:\/\//, '')}
-                      </span>
-                    </li>
-                  )}
-                </>
-              ))}
-            </ul>
-          </div>
-        )}
+        {letters.flatMap((letter) => {
+          if (isLetter(letter)) {
+            return (
+              <div className={styles['letter-group']}>
+                <div className={styles['letter-container']}>
+                  <h2 id={letter} className={styles.letter}>
+                    {letter.toUpperCase()}
+                  </h2>
+                </div>
+                <ul>
+                  {alphaIndex?.nodes?.flatMap((this_alpha) => {
+                    const url = this_alpha?.aToZFields?.url;
+                    if (
+                      url &&
+                      this_alpha
+                        ?.title()
+                        ?.toString()
+                        ?.toLowerCase()
+                        ?.match(`^${letter}`)
+                    ) {
+                      return (
+                        <li className={styles['result-title']}>
+                          <a href={url}>{this_alpha.title()}</a>
+                          <br />
+                          <span className={styles['result-url']}>
+                            {url.replace(/^https?:\/\//, '')}
+                          </span>
+                        </li>
+                      );
+                    } else {
+                      return [];
+                    }
+                  })}
+                </ul>
+              </div>
+            );
+          } else {
+            return [];
+          }
+        })}
       </section>
     </Layout>
   );

--- a/src/pages/alpha.tsx
+++ b/src/pages/alpha.tsx
@@ -95,9 +95,11 @@ function Alpha() {
           {isLetter('[0-9]') && <a href="#num">#</a>}
           {letters.flatMap((letter) =>
             isLetter(letter) ? (
-              <a href={`#${letter}`}>{letter.toUpperCase()}</a>
+              <a key={letter} href={`#${letter}`}>
+                {letter.toUpperCase()}
+              </a>
             ) : (
-              <></>
+              []
             )
           )}
         </div>
@@ -140,7 +142,7 @@ function Alpha() {
               </h2>
             </div>
             <ul>
-              {alphaIndex?.nodes?.flatMap((this_alpha) => {
+              {alphaIndex?.nodes?.flatMap((this_alpha, i) => {
                 const url = this_alpha?.aToZFields?.url;
                 if (
                   url &&
@@ -151,7 +153,7 @@ function Alpha() {
                     ?.match('^[0-9]')
                 ) {
                   return (
-                    <li className={styles['result-title']}>
+                    <li key={i} className={styles['result-title']}>
                       <a href={url}>{this_alpha.title()}</a>
                       <br />
                       <span className={styles['result-url']}>
@@ -169,14 +171,14 @@ function Alpha() {
         {letters.flatMap((letter) => {
           if (isLetter(letter)) {
             return (
-              <div className={styles['letter-group']}>
+              <div key={letter} className={styles['letter-group']}>
                 <div className={styles['letter-container']}>
                   <h2 id={letter} className={styles.letter}>
                     {letter.toUpperCase()}
                   </h2>
                 </div>
                 <ul>
-                  {alphaIndex?.nodes?.flatMap((this_alpha) => {
+                  {alphaIndex?.nodes?.flatMap((this_alpha, i) => {
                     const url = this_alpha?.aToZFields?.url;
                     if (
                       url &&
@@ -187,7 +189,7 @@ function Alpha() {
                         ?.match(`^${letter}`)
                     ) {
                       return (
-                        <li className={styles['result-title']}>
+                        <li key={i} className={styles['result-title']}>
                           <a href={url}>{this_alpha.title()}</a>
                           <br />
                           <span className={styles['result-url']}>

--- a/src/pages/category/[categorySlug]/[paginationTerm]/[categoryCursor].tsx
+++ b/src/pages/category/[categorySlug]/[paginationTerm]/[categoryCursor].tsx
@@ -1,12 +1,25 @@
-import { GetStaticPropsContext } from 'next';
+import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from 'next';
 import Page from 'pages/category/[categorySlug]';
 import { getNextStaticProps } from '@faustjs/next';
 import { client } from 'client';
+import { ParsedUrlQuery } from 'querystring';
+
+interface Params extends ParsedUrlQuery {
+  paginationTerm?: 'after' | 'before';
+}
+
+interface Props {}
 
 export default Page;
 
-export async function getStaticProps(context: GetStaticPropsContext) {
+export const getStaticProps: GetStaticProps<Props, Params> = async (
+  context
+) => {
+  if (!context.params)
+    throw Error('There should be a `context.params` but none was found.');
+
   const { paginationTerm } = context.params;
+
   if (!(paginationTerm === 'after' || paginationTerm === 'before')) {
     return {
       notFound: true,
@@ -17,11 +30,11 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     Page,
     client,
   });
-}
+};
 
-export function getStaticPaths() {
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
   return {
     paths: [],
     fallback: 'blocking',
   };
-}
+};

--- a/src/pages/category/[categorySlug]/index.tsx
+++ b/src/pages/category/[categorySlug]/index.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { Header, Footer, Posts, Pagination } from 'components';
 import { GetStaticPropsContext } from 'next';
 import { useRouter } from 'next/router';
-import { client } from 'client';
+import { client, Post } from 'client';
 
 const POSTS_PER_PAGE = 6;
 
@@ -24,8 +24,8 @@ export default function Page() {
   return (
     <>
       <Header
-        title={generalSettings.title}
-        description={generalSettings.description}
+        title={generalSettings?.title || undefined}
+        description={generalSettings?.description || undefined}
       />
 
       <Head>
@@ -35,16 +35,18 @@ export default function Page() {
       <main className="content content-single">
         <div className="wrap">
           <h2>Category: {category?.name}</h2>
-          <Posts posts={posts.nodes} />
+          {/* probably tweak `Posts` to avoid the `as` here */}
+          <Posts posts={(posts?.nodes || []) as Post[]} />
 
           <Pagination
-            pageInfo={posts.pageInfo}
+            /* probably tweak `Pagination` to avoid the `!` */
+            pageInfo={posts?.pageInfo!}
             basePath={`/category/${categorySlug}`}
           />
         </div>
       </main>
 
-      <Footer copyrightHolder={generalSettings.title} />
+      <Footer copyrightHolder={generalSettings?.title || undefined} />
     </>
   );
 }

--- a/src/pages/custom-page.tsx
+++ b/src/pages/custom-page.tsx
@@ -11,12 +11,12 @@ export default function Page() {
   return (
     <>
       <Header
-        title={generalSettings.title}
-        description={generalSettings.description}
+        title={generalSettings?.title || undefined}
+        description={generalSettings?.description || undefined}
       />
 
       <Head>
-        <title>Custom Page - {generalSettings.title}</title>
+        <title>Custom Page - {generalSettings?.title}</title>
       </Head>
 
       <PageTitle title="Custom Page" />
@@ -38,7 +38,7 @@ export default function Page() {
         </div>
       </main>
 
-      <Footer copyrightHolder={generalSettings.title} />
+      <Footer copyrightHolder={generalSettings?.title || undefined} />
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,13 +40,13 @@ export default function Page() {
   return (
     <>
       <Header
-        title={generalSettings.title}
-        description={generalSettings.description}
+        title={generalSettings?.title || undefined}
+        description={generalSettings?.description || undefined}
       />
 
       <Head>
         <title>
-          {generalSettings.title} - {generalSettings.description}
+          {generalSettings?.title} - {generalSettings?.description}
         </title>
       </Head>
       <Hero />
@@ -62,12 +62,14 @@ export default function Page() {
         <main id="content">
           <div
             className="entry-content container-xxl"
-            dangerouslySetInnerHTML={{ __html: frontPageContent?.content() }}
+            dangerouslySetInnerHTML={{
+              __html: frontPageContent?.content?.() || '',
+            }}
           />
         </main>
       </div>
 
-      <Footer copyrightHolder={generalSettings.title} />
+      <Footer copyrightHolder={generalSettings?.title || undefined} />
     </>
   );
 }

--- a/src/pages/posts/[postSlug]/[postCursor].tsx
+++ b/src/pages/posts/[postSlug]/[postCursor].tsx
@@ -1,11 +1,23 @@
 import { getNextStaticProps } from '@faustjs/next';
-import { GetStaticPropsContext } from 'next';
+import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from 'next';
 import Page from '..';
 import { client } from 'client';
+import { ParsedUrlQuery } from 'querystring';
+
+interface Params extends ParsedUrlQuery {
+  postSlug?: 'after' | 'before';
+}
+
+interface Props {}
 
 export default Page;
 
-export async function getStaticProps(context: GetStaticPropsContext) {
+export const getStaticProps: GetStaticProps<Props, Params> = async (
+  context
+) => {
+  if (!context.params)
+    throw Error('There should be a `context.params` but none was found.');
+
   const { postSlug } = context.params;
 
   if (!(postSlug === 'after' || postSlug === 'before')) {
@@ -18,11 +30,11 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     Page,
     client,
   });
-}
+};
 
-export function getStaticPaths() {
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
   return {
     paths: [],
     fallback: 'blocking',
   };
-}
+};

--- a/src/pages/posts/[postSlug]/index.tsx
+++ b/src/pages/posts/[postSlug]/index.tsx
@@ -5,7 +5,7 @@ import { GetStaticPropsContext } from 'next';
 import Head from 'next/head';
 
 export interface PostProps {
-  post: Post | Post['preview']['node'] | null | undefined;
+  post: Post | null | undefined;
 }
 
 export function PostComponent({ post }: PostProps) {
@@ -15,19 +15,19 @@ export function PostComponent({ post }: PostProps) {
   return (
     <>
       <Header
-        title={generalSettings.title}
-        description={generalSettings.description}
+        title={generalSettings?.title || undefined}
+        description={generalSettings?.description || undefined}
       />
 
       <Head>
         <title>
-          {post?.title()} - {generalSettings.title}
+          {post?.title()} - {generalSettings?.title}
         </title>
       </Head>
 
       <PageTitle
-        title={post?.title()}
-        bgImage={post?.featuredImage?.node?.sourceUrl()}
+        title={post?.title() || ''}
+        bgImage={post?.featuredImage?.node?.sourceUrl() || undefined}
       />
 
       <main className="content content-single">
@@ -36,7 +36,7 @@ export function PostComponent({ post }: PostProps) {
         </div>
       </main>
 
-      <Footer copyrightHolder={generalSettings.title} />
+      <Footer copyrightHolder={generalSettings?.title || undefined} />
     </>
   );
 }

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,5 +1,10 @@
 import { getNextStaticProps } from '@faustjs/next';
-import { client, OrderEnum, PostObjectsConnectionOrderbyEnum } from 'client';
+import {
+  client,
+  OrderEnum,
+  Post,
+  PostObjectsConnectionOrderbyEnum,
+} from 'client';
 import { Footer, Header, Pagination, Posts } from 'components';
 import { GetStaticPropsContext } from 'next';
 import Head from 'next/head';
@@ -29,28 +34,30 @@ export default function Page() {
   return (
     <>
       <Header
-        title={generalSettings.title}
-        description={generalSettings.description}
+        title={generalSettings?.title || undefined}
+        description={generalSettings?.description || undefined}
       />
 
       <Head>
         <title>
-          {generalSettings.title} - {generalSettings.description}
+          {generalSettings?.title} - {generalSettings?.description}
         </title>
       </Head>
 
       <main className="content content-index">
+        {/* probably tweak `Posts` to avoid the `as` here */}
         <Posts
-          posts={posts.nodes}
+          posts={(posts?.nodes || []) as Post[]}
           heading="Blog Posts"
           headingLevel="h2"
           postTitleLevel="h3"
           id={styles.post_list}
         />
-        <Pagination pageInfo={posts.pageInfo} basePath="/posts" />
+        {/* probably tweak `Pagination` to avoid the `!` */}
+        <Pagination pageInfo={posts?.pageInfo!} basePath="/posts" />
       </main>
 
-      <Footer copyrightHolder={generalSettings.title} />
+      <Footer copyrightHolder={generalSettings?.title || undefined} />
     </>
   );
 }

--- a/src/pages/vision.js
+++ b/src/pages/vision.js
@@ -41,6 +41,7 @@ function Vision() {
           strategy="beforeInteractive"
           type="text/javascript"
           src="js/vision.js"
+          defer
         ></script>
       </Head>
       <section className={styles.hero}>


### PR DESCRIPTION
- Fix "nested middleware" problem introduced with release of Next.js v.12.2.0
- Fix all build-blocking linting errors.
  - Mostly TypeScript errors, where possibly-undefined/null values needed to be accounted for.
    - Usually solved with syntax like `foo?.bar || ''` or `foo?.bar || undefined` (e.g.), which may not always be the best solution, but we can always refactor later as needed.
    - In other situations, switching from `.map` to `.flatMap` was called for (to make sure that items are skipped over completely if those possibly-undefined/null values were indeed empty). If this turns out to be too aggressive here or there, can refactor later.
  - Fix a couple of problems with how scripts were being imported (work here is not done, but this was needed to get the build working).
  - In `alpha`, also refactor to use loops.
  - In `Header`, also refactor to get secondary-nav working and to style "current" items in both primary- and secondary-nav.
  - Comment out a few unused files with problems (like `Sprite` and `TaggedPage`); if they later need to be used, then we can un-comment them and fix the problems at that time.