### PR TITLE
Extend core

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@faustjs/core": "^0.15.2",
     "@faustjs/next": "^0.15.1",
+    "@wordpress/block-library": "^7.13.0",
     "bootstrap": "5.1.3",
     "next": "^12.0.7",
     "normalize.css": "^8.0.1",

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -135,7 +135,7 @@
 @import './framework/styles/background';
 @import './framework/styles/blockquote';
 @import './framework/styles/breadcrumbs';
-@import './framework/styles/buttons';
+// @import './framework/styles/buttons';
 @import './framework/styles/frame';
 @import './framework/styles/gutenberg';
 @import './framework/styles/highlight_boxes';

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -89,6 +89,15 @@
 // @import './node_modules/utksds-framework/src/scss/styles/logos';
 // @import './node_modules/utksds-framework/src/scss/styles/wp';
 
+// ------  WP Core Block Styling
+// @import '@wordpress/block-library/build-style/style.css';
+// @import '@wordpress/block-library/build-style/theme.css';
+
+@import '@wordpress/block-library/build-style/button/style.css';
+@import '@wordpress/block-library/build-style/buttons/style.css';
+@import '@wordpress/block-library/build-style/columns/style.css';
+@import '@wordpress/block-library/build-style/cover/style.css';
+
 // ------  UT Regions – LOCAL
 @import './framework/regions/contentarea';
 @import './framework/regions/extended_footer';
@@ -144,12 +153,5 @@
 //webfont was not originally pulled in from the framework, commenting out for now
 
 // Main Site
-
-// @import '@wordpress/block-library/build-style/style.css';
-// @import '@wordpress/block-library/build-style/theme.css';
-@import '@wordpress/block-library/build-style/button/style.css';
-@import '@wordpress/block-library/build-style/buttons/style.css';
-@import '@wordpress/block-library/build-style/columns/style.css';
-@import '@wordpress/block-library/build-style/cover/style.css';
 
 @import '_extended';

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -145,4 +145,11 @@
 
 // Main Site
 
+// @import '@wordpress/block-library/build-style/style.css';
+// @import '@wordpress/block-library/build-style/theme.css';
+@import '@wordpress/block-library/build-style/button/style.css';
+@import '@wordpress/block-library/build-style/buttons/style.css';
+@import '@wordpress/block-library/build-style/columns/style.css';
+@import '@wordpress/block-library/build-style/cover/style.css';
+
 @import '_extended';


### PR DESCRIPTION
Pulling in base style sheets for WP core blocks into main
– Button
– Buttons
– Cover
– Columns