### PR TITLE
rename reactified vision page, tell Nextjs not to build it (for #47)

### DIFF
--- a/src/pages/vision-reactified.js
+++ b/src/pages/vision-reactified.js
@@ -411,3 +411,10 @@ function Vision() {
 }
 
 export default Vision;
+
+// just to get Next.js not to build this page for now
+export async function getStaticProps() {
+  return {
+    notFound: true,
+  };
+}


### PR DESCRIPTION
- Rename file for Reactified `/vision` page from `vision` to `vision-reactified` (to prevent name-conflict with static `/vision` endpoint that will be added).
- Set `vision-reactified` file to not actually build a page.

(for #47)