### PR TITLE
SlateFormEmbed and RequestInfoTabs

### DIFF
--- a/src/components/ParsedMarkup.tsx
+++ b/src/components/ParsedMarkup.tsx
@@ -7,40 +7,79 @@ import parse, {
 } from 'html-react-parser';
 
 import Link from 'next/link';
+import RequestInfoTabs from './RequestInfoTabs';
 // import Image from 'next/image';
 
 // workaround b/c of this bug: https://github.com/remarkablemark/html-react-parser/issues/633
 const isElement = (domNode: DOMNode): domNode is DOMHandlerElement =>
   domNode.type === 'tag';
 
-const parserConfig: HTMLReactParserOptions = {
-  replace(domNode) {
-    if (!isElement(domNode)) return;
+const toReactNode = ({
+  content,
+  isRequestInfo,
+}: {
+  content: string;
+  isRequestInfo?: boolean;
+}) => {
+  let needsRequestInfoTabs = !!isRequestInfo;
 
-    const attribs: Partial<typeof domNode.attribs> = domNode.attribs;
+  const parserConfig: HTMLReactParserOptions = {
+    replace(domNode) {
+      if (!isElement(domNode)) return;
 
-    switch (domNode.name) {
-      // use `next/link` for internal-links
-      case 'a': {
-        // not yet finalized, but we want a flag set up on the server to indicate that a link is internal
-        const { href, 'data-internal-link': dataInternalLink } = attribs;
+      const attribs: Partial<typeof domNode.attribs> = domNode.attribs;
 
-        if (href && dataInternalLink === 'true') {
-          delete attribs.href;
-          return <Link href={href}>{domToReact([domNode], parserConfig)}</Link>;
+      switch (domNode.name) {
+        // use `next/link` for internal-links
+        case 'a': {
+          // not yet finalized, but we want a flag set up on the server to indicate that a link is internal
+          const { href, 'data-internal-link': dataInternalLink } = attribs;
+
+          if (href && dataInternalLink === 'true') {
+            delete attribs.href;
+            return (
+              <Link href={href}>{domToReact([domNode], parserConfig)}</Link>
+            );
+          }
+        }
+
+        /*
+          Temporary hacky way of inserting `RequestInfoTabs` into `/requestinfo` page.
+          Eventually we'll want to use an HTML comment on the WP side to flag where the
+          `RequestInfoTabs` component should be inserted (and we shouldn't need an `isRequestInfo`
+          boolean at all, then).
+        */
+        case 'div': {
+          if (!isRequestInfo) return;
+          if (needsRequestInfoTabs) {
+            needsRequestInfoTabs = false;
+            return <RequestInfoTabs />;
+          } else {
+            return <></>;
+          }
         }
       }
-    }
-  },
+    },
+  };
+
+  const parsedContent = parse(content, parserConfig);
+
+  return <>{parsedContent}</>;
 };
 
 interface Props {
   /** The HTML content to parse. */
   content: string;
+  /** Page slug. */
+  slug?: string;
 }
 
-const ParsedMarkup = ({ content }: Props) => (
-  <>{parse(content, parserConfig)}</>
-);
+const ParsedMarkup = ({ content, slug }: Props) => {
+  const isRequestInfo = slug === 'requestinfo';
+
+  const parsedContent = toReactNode({ content, isRequestInfo });
+
+  return parsedContent;
+};
 
 export default ParsedMarkup;

--- a/src/components/RequestInfoTabs.tsx
+++ b/src/components/RequestInfoTabs.tsx
@@ -18,7 +18,7 @@ const RequestInfoTabs = () => {
       <Tab
         title="Undergraduate Information"
         eventKey="undergraduate"
-        className="nav-item"
+        className="nav-item my-4"
       >
         <SlateFormEmbed
           id={UNDERGRAD_ID}
@@ -33,7 +33,7 @@ const RequestInfoTabs = () => {
       <Tab
         title="Graduate Information"
         eventKey="graduate"
-        className="nav-item"
+        className="nav-item my-4"
       >
         <SlateFormEmbed
           id={GRAD_ID}

--- a/src/components/RequestInfoTabs.tsx
+++ b/src/components/RequestInfoTabs.tsx
@@ -1,0 +1,54 @@
+import Tabs from 'react-bootstrap/Tabs';
+import Tab from 'react-bootstrap/Tab';
+import SlateFormEmbed from './SlateFormEmbed';
+import { useEffect, useState } from 'react';
+
+const UNDERGRAD_ID = '03b73a18-fab9-4d73-bb2b-38eb3372937b';
+const GRAD_ID = '99443a39-fc22-40a9-a28f-d81171bbbf48';
+
+const RequestInfoTabs = () => {
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  return isHydrated ? (
+    <Tabs className="nav nav-pills justify-content-center justify-content-lg-start">
+      <Tab
+        title="Undergraduate Information"
+        eventKey="undergraduate"
+        className="nav-item"
+      >
+        <SlateFormEmbed
+          id={UNDERGRAD_ID}
+          scriptSrc={
+            `https://govols.utk.edu/register/?id=${UNDERGRAD_ID}&output=embed&div=form_${UNDERGRAD_ID}` +
+            (location.search.length > 1
+              ? '&' + location.search.substring(1)
+              : '')
+          }
+        />
+      </Tab>
+      <Tab
+        title="Graduate Information"
+        eventKey="graduate"
+        className="nav-item"
+      >
+        <SlateFormEmbed
+          id={GRAD_ID}
+          scriptSrc={
+            `https://apply.gradschool.utk.edu/register/?id=${GRAD_ID}&output=embed&div=form_${GRAD_ID}` +
+            (location.search.length > 1
+              ? '&' + location.search.substring(1)
+              : '')
+          }
+        />
+      </Tab>
+    </Tabs>
+  ) : (
+    <></>
+  );
+};
+
+export default RequestInfoTabs;

--- a/src/components/SlateFormEmbed.tsx
+++ b/src/components/SlateFormEmbed.tsx
@@ -1,0 +1,97 @@
+import { memo, useEffect, useRef } from 'react';
+
+const TARGET_STRINGS = ['cdn.technolutions.net'];
+
+type ScriptOrLink = HTMLScriptElement | HTMLLinkElement;
+
+const assetsByScriptSrc = new Map<string, ScriptOrLink[]>();
+
+const addRelatedAssetsIfNeeded = (script: HTMLScriptElement) => {
+  const assets = assetsByScriptSrc.get(script.src);
+  if (!assets) return;
+
+  assets.forEach((asset) => {
+    if (document.head.contains(asset)) return;
+    document.head.appendChild(asset);
+  });
+};
+
+const removeRelatedAssets = (script: HTMLScriptElement) => {
+  if (!assetsByScriptSrc.has(script.src)) {
+    const assets: ScriptOrLink[] = [];
+
+    const allNextSiblings: ChildNode[] = [];
+    let sibling: ChildNode | null = script;
+    while ((sibling = sibling.nextSibling)) {
+      allNextSiblings.push(sibling);
+    }
+
+    allNextSiblings.forEach((sibling) => {
+      if (sibling instanceof HTMLScriptElement) {
+        if (TARGET_STRINGS.some((s) => sibling.src.includes(s))) {
+          return void assets.push(sibling);
+        }
+      } else if (sibling instanceof HTMLLinkElement) {
+        if (TARGET_STRINGS.some((s) => sibling.href.includes(s))) {
+          return void assets.push(sibling);
+        }
+      }
+    });
+
+    assetsByScriptSrc.set(script.src, assets);
+  }
+
+  (assetsByScriptSrc.get(script.src) || []).forEach((asset) => {
+    asset.remove();
+  });
+};
+
+interface Props {
+  id: string;
+  scriptSrc: string;
+}
+
+/*
+  Use `memo` to ensure that once mounted, this component never re-renders (because
+  its only props -- `id` and `scriptSrc` -- should never change).
+  This makes it easy to ensure that the `useEffect()` hook runs only
+  on component mount/unmount (even though the props are included in its dependency array).
+*/
+const SlateFormEmbed = memo(({ id, scriptSrc }: Props) => {
+  const scriptRef = useRef<HTMLScriptElement>();
+
+  /*
+    On component-mount, load form-script, and, if necessary, re-add the extra related assets
+    that it itself fetched on the first mount (this is tricky because the script is "smart"
+    enough NOT to re-add those extra assets if it's already done so, and in this case we
+    need to work around that "smartness"). Our solution involves a global store that attempts
+    to keep track of which assets should go with which script. It probably isn't perfect,
+    but in testing it's working just fine.
+
+    On component-unmount, remove the form-script, and also remove the extra related assets.
+  */
+  useEffect(() => {
+    if (!scriptRef.current) {
+      scriptRef.current = document.createElement('script');
+      scriptRef.current.src = scriptSrc;
+    }
+
+    const script = scriptRef.current;
+
+    if (document.head.contains(script)) return;
+
+    document.head.appendChild(script);
+    addRelatedAssetsIfNeeded(script);
+
+    return () => {
+      removeRelatedAssets(script);
+      script.remove();
+    };
+  }, [id, scriptSrc]);
+
+  return <div id={`form_${id}`}></div>;
+});
+
+SlateFormEmbed.displayName = 'SlateFormEmbed';
+
+export default SlateFormEmbed;

--- a/src/pages/[...pageUri].tsx
+++ b/src/pages/[...pageUri].tsx
@@ -34,10 +34,7 @@ export function PageComponent({ page }: PageProps) {
       <main className={'content content-single ' + (pageSlug || '')}>
         <div className="container-xxl pt-5">
           <div>
-            <ParsedMarkup
-              content={page?.content() || ''}
-              slug={pageSlug || undefined}
-            />
+            <ParsedMarkup content={page?.content() || ''} />
           </div>
         </div>
       </main>

--- a/src/pages/[...pageUri].tsx
+++ b/src/pages/[...pageUri].tsx
@@ -34,7 +34,10 @@ export function PageComponent({ page }: PageProps) {
       <main className={'content content-single ' + (pageSlug || '')}>
         <div className="container-xxl pt-5">
           <div>
-            <ParsedMarkup content={page?.content() || ''} />
+            <ParsedMarkup
+              content={page?.content() || ''}
+              slug={pageSlug || undefined}
+            />
           </div>
         </div>
       </main>


### PR DESCRIPTION
- Build `SlateFormEmbed` component.
- Build `RequestInfoTabs` component that uses the new `SlateFormEmbed` component.
- Demo the `RequestInfoTabs` component on the `/requestinfo` page.
  - For now, just using a "hacky" method to include it in this page via the `ParsedMarkup` component. Before merging, the hacky method should be replaced with a more robust method (probably: on the WordPress side, leave an agreed-upon HTML comment where the `RequestInfoTabs` component should go, and use that as a flag in `ParsedMarkup` so that we can configure the parser accordingly).