### PR TITLE
Punchlist alpha

### DIFF
--- a/src/pages/alpha.tsx
+++ b/src/pages/alpha.tsx
@@ -210,7 +210,7 @@ const Alpha = () => {
       </div>
       <section className={styles['container']}>
         <div className={styles['search-container']}>
-          <h3>Browse the site index</h3>
+          <h2>Browse the site index</h2>
           <div>
             <form onSubmit={handleSubmit} className={styles['alpha-form']}>
               <TextField
@@ -257,9 +257,9 @@ const Alpha = () => {
           {activeChars.map((char) => (
             <div key={char} className={styles['letter-group']}>
               <div className={styles['letter-container']}>
-                <h2 id={toDomId(char)} className={styles.letter}>
+                <h3 id={toDomId(char)} className={styles.letter}>
                   {char}
-                </h2>
+                </h3>
               </div>
               <ul>
                 {itemsByChar.current.get(char)?.flatMap((item) =>

--- a/src/pages/alpha.tsx
+++ b/src/pages/alpha.tsx
@@ -279,6 +279,8 @@ const Alpha = () => {
             </div>
           ))}
         </section>
+      </section>
+      <section className={styles['request-container']}>
         <a
           href="https://communications.utk.edu/a-z-index-update-request/"
           className={styles.fancyLink}

--- a/src/scss/pages/alpha.module.scss
+++ b/src/scss/pages/alpha.module.scss
@@ -242,7 +242,10 @@ p.title {
     padding: 0 0 0 2%;
 
     @media screen and (min-width: 800px) {
-      width: 8vw;
+      // width: 8vw;
+      flex-basis: 10vw;
+      min-width: 10vw;
+      // border: 2px solid pink;
       text-align: right;
       margin-right: 1rem;
       text-align: center;
@@ -357,7 +360,7 @@ p.title {
     font-size: $h6-font-size;
     &:hover {
       background-color: $utsmokey;
-      color: white;
+      color: white !important;
     }
   }
 }

--- a/src/scss/pages/alpha.module.scss
+++ b/src/scss/pages/alpha.module.scss
@@ -98,8 +98,9 @@ p.title {
   overflow: visible !important;
 }
 .request-container {
-  width: 98vw;
+  max-width: 1820px;
   padding: 4vw 2vw;
+  margin: 0 auto;
 }
 
 .search-container {

--- a/src/scss/pages/alpha.module.scss
+++ b/src/scss/pages/alpha.module.scss
@@ -196,12 +196,12 @@ p.title {
   }
   @media screen and (min-width: 800px) {
     width: 100%;
+    margin: 3rem auto;
     [id] {
       @media (min-height: 200px) {
         scroll-margin-top: 0;
       }
     }
-    margin: 3rem auto;
   }
 }
 .letter-group {
@@ -224,7 +224,6 @@ p.title {
     background-color: white;
     text-align: left;
     align-self: flex-start;
-    border: 1px solid blue;
     @media screen and (min-width: 800px) {
       width: 10vw;
       text-align: right;

--- a/src/scss/pages/alpha.module.scss
+++ b/src/scss/pages/alpha.module.scss
@@ -90,13 +90,12 @@ p.title {
     font-size: 1.35rem;
   }
 }
-.container,
-.request-container {
+.container {
   position: relative;
   max-width: 1820px;
   margin: 0 auto;
   height: fit-content;
-  overflow: visible;
+  overflow: visible !important;
 }
 .request-container {
   width: 98vw;
@@ -111,8 +110,9 @@ p.title {
   top: -9rem;
   background-color: $white;
   z-index: 2;
+  // background-color: pink; /* for mobile this is above the results as they slide up */
   @media screen and (min-width: 800px) {
-    margin: 3rem auto;
+    // margin: 3rem auto;
     position: sticky;
     top: 8rem;
   }
@@ -130,16 +130,14 @@ p.title {
   position: relative;
   border-top: 0.6rem solid $utorange;
   border-bottom: 0.6rem solid $utorange;
-  margin: 2rem 0;
+  margin: 2rem 0 0 0;
   height: auto;
-  padding: 0.5rem 5%;
+  padding: 0.5rem 8%;
   @media screen and (min-width: 800px) {
     left: 0;
     width: 100%;
     padding: 3rem 5%;
-  }
-  h3 {
-    margin-top: $spacer;
+    margin: 2rem 0;
   }
 }
 
@@ -188,6 +186,7 @@ p.title {
 .results {
   width: 90%;
   margin: 0 auto;
+  // border: 1px solid green;
   [id] {
     /* sets the space the top needs to make sure letters are visible on jump */
     @media (min-height: 200px) {
@@ -209,25 +208,37 @@ p.title {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: 1rem 0 4rem 0;
+  margin: 1rem 0 1rem 0;
+  // border: 1px solid green;
 
   @media screen and (min-width: 800px) {
     flex-direction: row;
+
+    margin: 1rem 0 4rem 0;
   }
   .letter-container {
     text-align: center;
-    width: 100%;
+    width: 112%;
+    margin-left: -6%;
     position: -webkit-sticky;
     position: sticky;
-    display: inline-block;
+    display: block;
     top: -1px;
-    background-color: white;
+    top: 11rem;
+    // border: 1px solid red;
+    // z-index: 2;
+    background-color: white; /* keeps results from appearing under the letter on scroll */
+    // border: 1px solid blue;
     text-align: left;
     align-self: flex-start;
+    padding: 0 0 0 2%;
+
     @media screen and (min-width: 800px) {
-      width: 10vw;
+      width: 8vw;
       text-align: right;
-      margin-right: 2rem;
+      margin-right: 1rem;
+      text-align: center;
+      top: -1px;
     }
     @media screen and (min-width: 1500px) {
       width: 18%;
@@ -236,13 +247,15 @@ p.title {
     }
 
     h3.letter {
-      font-size: 4rem;
+      font-size: $h4-font-size;
       font-weight: $font-weight-bold;
       margin-top: 2rem;
       @media screen and (min-width: 800px) {
         width: auto;
         font-size: 5rem;
-        padding-right: 2rem;
+        font-size: calc($h3-font-size * 1.8);
+        font-size: $h2-font-size;
+        // padding-right: 2rem;
         margin-top: 1rem;
       }
       @media screen and (min-width: 1200px) {
@@ -418,7 +431,6 @@ CSS Grid layout for modern browsers:
     }
     .search-container {
       grid-column: 3 / 4;
-      width: auto;
     }
 
     .results {

--- a/src/scss/pages/alpha.module.scss
+++ b/src/scss/pages/alpha.module.scss
@@ -110,8 +110,9 @@ p.title {
     position: sticky;
     top: 8rem;
   }
-  h3 {
+  h2 {
     margin-top: 0;
+    font-size: $h3-font-size;
   }
 }
 
@@ -218,7 +219,7 @@ p.title {
       margin-right: 2rem;
     }
 
-    h2.letter {
+    h3.letter {
       font-size: 4rem;
       font-weight: $font-weight-bold;
       margin-top: 2rem;

--- a/src/scss/pages/alpha.module.scss
+++ b/src/scss/pages/alpha.module.scss
@@ -90,13 +90,19 @@ p.title {
     font-size: 1.35rem;
   }
 }
-.container {
+.container,
+.request-container {
   position: relative;
-  max-width: 1920px;
+  max-width: 1820px;
   margin: 0 auto;
   height: fit-content;
   overflow: visible;
 }
+.request-container {
+  width: 98vw;
+  padding: 4vw 2vw;
+}
+
 .search-container {
   width: 90%;
   margin: 3rem auto 0 auto;
@@ -168,6 +174,12 @@ p.title {
     @media screen and (min-width: 800px) {
       // font-size: 4.7rem;
       // flex: 0 1 5vw;
+      font-size: $h4-font-size;
+      flex: 0 1 6%;
+    }
+    @media screen and (min-width: 1200px) {
+      // font-size: 4.7rem;
+      // flex: 0 1 5vw;
       font-size: $h3-font-size;
       flex: 0 1 6%;
     }
@@ -175,7 +187,6 @@ p.title {
 }
 .results {
   width: 90%;
-
   margin: 0 auto;
   [id] {
     /* sets the space the top needs to make sure letters are visible on jump */
@@ -208,13 +219,19 @@ p.title {
     width: 100%;
     position: -webkit-sticky;
     position: sticky;
-    display: block;
+    display: inline-block;
     top: -1px;
     background-color: white;
     text-align: left;
     align-self: flex-start;
+    border: 1px solid blue;
     @media screen and (min-width: 800px) {
       width: 10vw;
+      text-align: right;
+      margin-right: 2rem;
+    }
+    @media screen and (min-width: 1500px) {
+      width: 18%;
       text-align: right;
       margin-right: 2rem;
     }
@@ -224,6 +241,12 @@ p.title {
       font-weight: $font-weight-bold;
       margin-top: 2rem;
       @media screen and (min-width: 800px) {
+        width: auto;
+        font-size: 5rem;
+        padding-right: 2rem;
+        margin-top: 1rem;
+      }
+      @media screen and (min-width: 1200px) {
         width: auto;
         font-size: 6.8rem;
         padding-right: 2rem;
@@ -241,6 +264,7 @@ p.title {
       list-style: none;
       margin: 0;
       padding: 0 0 2rem 0;
+      line-height: $line-height-base;
     }
     .result-title a {
       text-decoration: none;
@@ -248,8 +272,10 @@ p.title {
       padding: 0 0.5rem 0.2rem 0;
       margin-bottom: 0.1rem;
       display: inline-block;
+      width: auto;
       font-weight: $font-weight-bold;
       color: $utlinkriver;
+      line-height: $line-height-base;
       .result-search-term {
         font-weight: $font-weight-bolder;
       }
@@ -259,6 +285,10 @@ p.title {
     }
     .result-url {
       font-size: 0.9rem;
+      padding-top: 0.4rem;
+      display: inline-block;
+      word-break: break-all;
+      line-height: calc($line-height-base * 0.9);
     }
   }
 }
@@ -364,7 +394,7 @@ CSS Grid layout for modern browsers:
 /* Check for CSS Grid support: */
 @supports (grid-area: auto) {
   .container {
-    width: 100vw;
+    width: calc(100% - 2vw);
     display: grid;
     gap: 2vw;
     grid-template-columns: 1fr;
@@ -381,11 +411,30 @@ CSS Grid layout for modern browsers:
 
   @media screen and (min-width: 800px) {
     .container {
-      grid-template-columns: 1.7fr 1fr;
+      grid-template-columns: minmax(calc(55% + 4vw), 1.3fr) 1fr;
+      padding: 0 2vw;
+    }
+    .results {
+      grid-column: 1 / 2;
+    }
+    .search-container {
+      grid-column: 3 / 4;
+      width: auto;
+    }
+
+    .results {
+      grid-column: 1 / 2;
+      grid-row: 1 / 2;
+    }
+  }
+  @media screen and (min-width: 1300px) {
+    .container {
+      grid-template-columns: 2fr 1fr;
       padding: 0 2vw;
     }
     .search-container {
       grid-column: 2 / 3;
+      justify-self: start;
     }
 
     .results {

--- a/src/scss/pages/alpha.module.scss
+++ b/src/scss/pages/alpha.module.scss
@@ -133,11 +133,18 @@ p.title {
   margin: 2rem 0 0 0;
   height: auto;
   padding: 0.5rem 8%;
+  min-height: 185px;
+  display: flex;
+  align-content: center;
+  align-items: center;
   @media screen and (min-width: 800px) {
     left: 0;
     width: 100%;
     padding: 3rem 5%;
     margin: 2rem 0;
+  }
+  h3 {
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
– fix mobile breakpoints by allowing url string to wrap (this was breaking the alignment)
– add sticky letters back to mobile with reduced size alphabet
– fix height of search letters at mobile to allow sticky to snug to bottom no matter what search term
– fix alignment of result letters at mid size
– reduce result letter size at various breakpoints
– other minor style tweaks to tighten the appearance as a whole