### PR TITLE
Adding orange hash to the page title headlines

### DIFF
--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -30,7 +30,7 @@ function PageTitle({
       className={styles.hero}
     >
       <div className="container-xxl">
-        <h1 className="display-4">{title}</h1>
+        <h1 className="display-4 orange-mark">{title}</h1>
         <div className={styles.intro}>
           <div className={styles.children}>{children}</div>
           {buttonText && buttonURL && (

--- a/src/scss/framework/styles/_orange_mark.scss
+++ b/src/scss/framework/styles/_orange_mark.scss
@@ -1,22 +1,21 @@
-.orange-mark {
+.orange-mark,
+.display-4 {
   position: relative;
-  padding-top: $spacer*3;
-  margin-top: $spacer*3;
-  &:before {
-    content: "";
+  padding-bottom: $spacer * 2;
+  margin-top: $spacer * 3;
+  &::after {
+    content: '';
     position: absolute;
     left: 0;
     width: 90px;
     margin-left: 0;
-    height: 6px;
+    height: 8px;
     background-color: $utorange;
-    top: 0;
-    bottom: auto
+    top: auto;
+    bottom: 0;
   }
   &.widget-title {
-  padding-top: $spacer;
-  margin-top: $spacer;
+    padding-top: $spacer;
+    margin-top: $spacer;
   }
 }
-
-


### PR DESCRIPTION
## New "Default Header" style

- Reconfigured "orange mark" style to be `::after` instead of `::before`. The style is found at `src/scss/framework/styles/_orange_mark`
- Added the `.orange_marke` class to the default page title. (File in `src/components/PageTitle.tsx`)