### PR TITLE
Changing www links to prod.ws

### DIFF
--- a/public/css/meet.css
+++ b/public/css/meet.css
@@ -781,14 +781,14 @@ textarea.form-control.is-invalid {
   background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjIuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHdpZHRoPSI3M3B4IiBoZWlnaHQ9IjYzLjVweCIgdmlld0JveD0iMCAwIDczIDYzLjUiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDczIDYzLjU7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDpub25lO30KCS5zdDF7ZmlsbDpub25lO3N0cm9rZTojNTg1OTVCO30KCS5zdDJ7Zm9udC1mYW1pbHk6J0dvdGhhbS1VbHRyYUl0YWxpYyc7fQoJLnN0M3tmb250LXNpemU6NjVweDt9Cgkuc3Q0e2xldHRlci1zcGFjaW5nOjY7fQoJLnN0NXtmaWxsOm5vbmU7c3Ryb2tlOiNGRjgyMDA7c3Ryb2tlLXdpZHRoOjIuNTt9Cgkuc3Q2e2VuYWJsZS1iYWNrZ3JvdW5kOm5ldyAgICA7fQo8L3N0eWxlPgo8cmVjdCB4PSItNTczLjYiIHk9IjE5IiBjbGFzcz0ic3QwIiB3aWR0aD0iNjY2LjQiIGhlaWdodD0iMTkyLjUiLz4KPHRleHQgdHJhbnNmb3JtPSJtYXRyaXgoMSAwIDAgMSAtNTczLjY0MjYgNjYuNDU0NCkiPjx0c3BhbiB4PSIwIiB5PSIwIiBjbGFzcz0ic3QxIHN0MiBzdDMgc3Q0Ij5FWFBFUklFTkNFIDwvdHNwYW4+PHRzcGFuIHg9IjAiIHk9Ijc2IiBjbGFzcz0ic3QxIHN0MiBzdDMgc3Q0Ij5DQU1QVVM8L3RzcGFuPjwvdGV4dD4KPGc+Cgk8ZGVmcz4KCQk8cmVjdCBpZD0iU1ZHSURfMV8iIHk9IjYuNSIgd2lkdGg9IjczIiBoZWlnaHQ9IjU3Ii8+Cgk8L2RlZnM+Cgk8Y2xpcFBhdGggaWQ9IlNWR0lEXzJfIj4KCQk8dXNlIHhsaW5rOmhyZWY9IiNTVkdJRF8xXyIgIHN0eWxlPSJvdmVyZmxvdzp2aXNpYmxlOyIvPgoJPC9jbGlwUGF0aD4KPC9nPgo8ZyBjbGFzcz0ic3Q2Ij4KCTxwYXRoIGNsYXNzPSJzdDUiIGQ9Ik0yLjgsMzQuN2MwLTE5LjQsMTEtMjYsMjYuOC0yNi43bDIuMiwxMC4xQzIzLjksMTkuMSwyMCwyMi44LDIwLDI5aDEwLjVWNTdIMi44VjM0Ljd6IE0zNi42LDM0LjcKCQljMC0xOS40LDExLTI2LDI2LjgtMjYuN2wyLjIsMTAuMWMtNy45LDEtMTEuOCw0LjYtMTEuOCwxMC45aDEwLjVWNTdIMzYuNlYzNC43eiIvPgo8L2c+Cjwvc3ZnPgo=');
 }
 .bg-aerial {
-  background-image: url(https://www.utk.edu/images/i/warmers/aerial_1.jpg);
+  background-image: url(https://prod.ws.utk.edu/images/i/warmers/aerial_1.jpg);
 }
 .bg-campus {
   background-attachment: fixed;
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
-  background-image: url(https://www.utk.edu/images/i/warmers/studentsoncampus_1.jpg);
+  background-image: url(https://prod.ws.utk.edu/images/i/warmers/studentsoncampus_1.jpg);
 }
 .bg-homesweet {
   padding-top: 25rem;
@@ -800,7 +800,7 @@ textarea.form-control.is-invalid {
   background-size: cover;
 }
 .framed::after {
-  background-image: url(https://www.utk.edu/images/i/warmers/strip_gingham.gif);
+  background-image: url(https://prod.ws.utk.edu/images/i/warmers/strip_gingham.gif);
 }
 .site-title {
   font-size: 1.5625rem;

--- a/public/meet.html
+++ b/public/meet.html
@@ -36,7 +36,7 @@
     />
     <link
       rel="stylesheet"
-      href="//images.utk.edu/designsystem/meet/style20201118.css"
+      href="//images.utk.edu/designsystem/meet/style20221215.css"
     />
     <link rel="stylesheet" href="/css/meet.css" />
     <script src="https://cdn.jsdelivr.net/npm/lozad/dist/lozad.min.js"></script>
@@ -54,7 +54,7 @@
     />
     <meta
       property="og:image"
-      content="https://www.utk.edu/images/i/warmers/meet_web_students_bench_1.jpg"
+      content="https://prod.ws.utk.edu/images/i/warmers/meet_web_students_bench_1.jpg"
     />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@utknoxville" />
@@ -864,7 +864,7 @@
       <div
         class="row bg-light align-items-end mb-md-5 mb-lg-0 align-items-lg-center bg-img-header no-gutters"
         style="
-          background-image: url('https://www.utk.edu/images/i/warmers/2021-smokey_header.jpg');
+          background-image: url('https://prod.ws.utk.edu/images/i/warmers/2021-smokey_header.jpg');
         "
       >
         <div class="container-top">
@@ -904,7 +904,7 @@
         <div class="container-fluid bg-orange pt-lg-1 pb-5">
           <div
             class="col-12 col-md-10 offset-md-1 mt-n5 lozad bg-homesweet"
-            data-background-image="https://www.utk.edu/images/i/warmers/campusview_1.jpg"
+            data-background-image="https://prod.ws.utk.edu/images/i/warmers/campusview_1.jpg"
           >
             <div class="row align-items-end">
               <div
@@ -928,7 +928,7 @@
 
         <div
           class="container-fluid bg-smokey text-center py-5 bg-img-cta lozad row no-gutters align-items-center"
-          data-background-image="https://www.utk.edu/images/i/warmers/meet_web_ayres_gray_bg_1.jpg"
+          data-background-image="https://prod.ws.utk.edu/images/i/warmers/meet_web_ayres_gray_bg_1.jpg"
           style="background-size: cover"
         >
           <div class="col-12 col-md-6 mx-auto">
@@ -964,7 +964,7 @@
         <!-- ============ -->
         <div
           class="container-fluid bg-light lozad pb-4 py-md-5"
-          data-background-image="https://www.utk.edu/images/i/warmers/meet_web_mtn_bg_1.jpg"
+          data-background-image="https://prod.ws.utk.edu/images/i/warmers/meet_web_mtn_bg_1.jpg"
         >
           <div class="container">
             <div class="row align-items-center mt-5">
@@ -984,7 +984,7 @@
               </div>
               <div class="col-12 col-lg-6 col-xl-4 offset-xl-1 mb-4 mb-lg-0">
                 <img
-                  src="https://www.utk.edu/images/i/warmers/arrow_1.svg"
+                  src="https://prod.ws.utk.edu/images/i/warmers/arrow_1.svg"
                   class="img-arrow"
                   alt=""
                 />
@@ -1050,35 +1050,35 @@
                     <source
                       media="(min-width: 1000px)"
                       srcset="
-                        https://www.utk.edu/images/i/warmers/2021-Lab_900x1100.jpg
+                        https://prod.ws.utk.edu/images/i/warmers/2021-Lab_900x1100.jpg
                       "
                     />
                     <source
                       media="(min-width: 992px)"
                       srcset="
-                        https://www.utk.edu/images/i/warmers/2021-Lab_900x1100.jpg
+                        https://prod.ws.utk.edu/images/i/warmers/2021-Lab_900x1100.jpg
                       "
                     />
                     <source
                       media="(min-width: 768px)"
                       srcset="
-                        https://www.utk.edu/images/i/warmers/sciencesat_300x750.jpg
+                        https://prod.ws.utk.edu/images/i/warmers/sciencesat_300x750.jpg
                       "
                     />
                     <source
                       media="(min-width: 576px)"
                       srcset="
-                        https://www.utk.edu/images/i/warmers/sciencesat_300x75dd0.jpg
+                        https://prod.ws.utk.edu/images/i/warmers/sciencesat_300x75dd0.jpg
                       "
                     />
                     <source
                       srcset="
-                        https://www.utk.edu/images/i/warmers/2021-Lab_900x800.jpg
+                        https://prod.ws.utk.edu/images/i/warmers/2021-Lab_900x800.jpg
                       "
                     />
                     <noscript
                       ><img
-                        src="https://www.utk.edu/images/i/warmers/2021-Lab_900x800.jpg"
+                        src="https://prod.ws.utk.edu/images/i/warmers/2021-Lab_900x800.jpg"
                         alt=""
                     /></noscript>
                   </picture>
@@ -1150,7 +1150,7 @@
           <div>
             <div
               class="container-fluid bg-light pb-4 py-md-5 no-gutters lozad"
-              data-background-image="https://www.utk.edu/images/i/warmers/repeatingpattern_white_1.jpg"
+              data-background-image="https://prod.ws.utk.edu/images/i/warmers/repeatingpattern_white_1.jpg"
             >
               <div class="container">
                 <div class="row align-items-center mt-5">
@@ -1195,7 +1195,7 @@
 
             <div
               class="container-fluid bg-smokey text-center py-5 bg-img-cta lozad row no-gutters align-items-center"
-              data-background-image="https://www.utk.edu/images/i/warmers/experiencecampus_1.svg"
+              data-background-image="https://prod.ws.utk.edu/images/i/warmers/experiencecampus_1.svg"
             >
               <div class="col-12 col-md-6 mx-auto">
                 <svg
@@ -1237,7 +1237,7 @@
                   <div class="col-12 col-lg-10 offset-lg-1 mt-md-n5">
                     <img
                       class="lozad"
-                      data-src="https://www.utk.edu/images/i/warmers/knox_skyline.jpg"
+                      data-src="https://prod.ws.utk.edu/images/i/warmers/knox_skyline.jpg"
                       width="1800"
                       height="600"
                       alt="Knoxville Skyline"
@@ -1272,29 +1272,29 @@
                             <source
                               media="(min-width: 1200px)"
                               srcset="
-                                https://www.utk.edu/images/i/warmers/wakeboard_lg-1.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/wakeboard_lg-1.jpg
                               "
                             />
                             <source
                               media="(min-width: 992px)"
                               srcset="
-                                https://www.utk.edu/images/i/warmers/wakeboard_md.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/wakeboard_md.jpg
                               "
                             />
                             <source
                               media="(min-width: 768px)"
                               srcset="
-                                https://www.utk.edu/images/i/warmers/wakeboard_sm.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/wakeboard_sm.jpg
                               "
                             />
                             <source
                               srcset="
-                                https://www.utk.edu/images/i/warmers/wakeboard_xs.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/wakeboard_xs.jpg
                               "
                             />
                             <noscript
                               ><img
-                                src="https://www.utk.edu/images/i/warmers/wakeboard_xs.jpg"
+                                src="https://prod.ws.utk.edu/images/i/warmers/wakeboard_xs.jpg"
                                 width="600"
                                 height="900"
                                 alt="Wake Board"
@@ -1306,29 +1306,29 @@
                             <source
                               media="(min-width: 1200px)"
                               srcset="
-                                https://www.utk.edu/images/i/warmers/bike_lg-1.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/bike_lg-1.jpg
                               "
                             />
                             <source
                               media="(min-width: 992px)"
                               srcset="
-                                https://www.utk.edu/images/i/warmers/bike_md.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/bike_md.jpg
                               "
                             />
                             <source
                               media="(min-width: 768px)"
                               srcset="
-                                https://www.utk.edu/images/i/warmers/bike_sm.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/bike_sm.jpg
                               "
                             />
                             <source
                               srcset="
-                                https://www.utk.edu/images/i/warmers/bike_xs.jpg
+                                https://prod.ws.utk.edu/images/i/warmers/bike_xs.jpg
                               "
                             />
                             <noscript
                               ><img
-                                src="https://www.utk.edu/images/i/warmers/bike_xl.jpg"
+                                src="https://prod.ws.utk.edu/images/i/warmers/bike_xl.jpg"
                                 width="600"
                                 height="900"
                                 alt="Mountain biking."
@@ -1353,17 +1353,17 @@
                           <source
                             media="(min-width: 992px)"
                             srcset="
-                              https://www.utk.edu/images/i/warmers/2021-smokies.jpg
+                              https://prod.ws.utk.edu/images/i/warmers/2021-smokies.jpg
                             "
                           />
                           <source
                             srcset="
-                              https://www.utk.edu/images/i/warmers/2021-marketsquare_xs.jpg
+                              https://prod.ws.utk.edu/images/i/warmers/2021-marketsquare_xs.jpg
                             "
                           />
                           <noscript
                             ><img
-                              src="https://www.utk.edu/images/i/warmers/2021-smokies.jpg"
+                              src="https://prod.ws.utk.edu/images/i/warmers/2021-smokies.jpg"
                               width="600"
                               height="900"
                               alt="The Smokies."
@@ -1381,7 +1381,7 @@
           <div id="afford">
             <div
               class="container-fluid bg-light pb-4 py-md-5 no-gutters lozad"
-              data-background-image="https://www.utk.edu/images/i/warmers/texture_2.jpg"
+              data-background-image="https://prod.ws.utk.edu/images/i/warmers/texture_2.jpg"
             >
               <div class="container">
                 <div class="row align-items-center mt-5">
@@ -1446,7 +1446,7 @@
 
             <div
               class="container-fluid bg-smokey text-center py-5 bg-img-cta lozad row no-gutters align-items-center"
-              data-background-image="https://www.utk.edu/images/i/warmers/texture_rowing.jpg"
+              data-background-image="https://prod.ws.utk.edu/images/i/warmers/texture_rowing.jpg"
               style="background-size: cover"
             >
               <div class="col-12 col-md-6 mx-auto">
@@ -1483,7 +1483,7 @@
             <div class="container-fluid bg-orange pt-lg-1 pb-5">
               <div
                 class="col-12 col-md-10 offset-md-1 mt-lg-n5 bg-img-scroll lozad bg-community"
-                data-background-image="https://www.utk.edu/images/i/warmers/2021-community_service.jpg"
+                data-background-image="https://prod.ws.utk.edu/images/i/warmers/2021-community_service.jpg"
               >
                 <div class="row align-items-end">
                   <div
@@ -1522,7 +1522,7 @@
 
             <div
               class="container-fluid bg-smokey text-center py-5 bg-img-cta lozad row no-gutters align-items-center"
-              data-background-image="https://www.utk.edu/images/i/warmers/2021-becomeavol_1.svg"
+              data-background-image="https://prod.ws.utk.edu/images/i/warmers/2021-becomeavol_1.svg"
             >
               <div class="col-12 col-md-6 mx-auto">
                 <svg
@@ -1558,7 +1558,7 @@
             <div class="container-fluid bg-orange py-3 py-md-5">
               <div
                 class="col-12 col-md-10 offset-md-1 bg-img-scroll lozad bg-traditions"
-                data-background-image="https://www.utk.edu/images/i/warmers/2021-smokey_photoop2.jpg"
+                data-background-image="https://prod.ws.utk.edu/images/i/warmers/2021-smokey_photoop2.jpg"
               >
                 <div class="row align-items-end">
                   <div
@@ -1608,7 +1608,7 @@
 
             <div
               class="container-fluid bg-smokey text-center py-5 bg-img-cta lozad row no-gutters align-items-center"
-              data-background-image="https://www.utk.edu/images/i/warmers/repeatingpattern_gray_1.jpg"
+              data-background-image="https://prod.ws.utk.edu/images/i/warmers/repeatingpattern_gray_1.jpg"
               style="background-size: cover"
             >
               <div class="col-12 col-md-6 mx-auto">


### PR DESCRIPTION
## Meet Image Path

- Upon launch, many image links were set to the old url structure www.utk.edu/images/i/warmers, etc.
- Many images could not be easily recovered
- So, changes were made, to simply point to prod.ws.utk.edu

