### PR TITLE
Responsive cleanup

### DIFF
--- a/src/scss/core-blocks/_layout.scss
+++ b/src/scss/core-blocks/_layout.scss
@@ -19,13 +19,35 @@
     margin-left: 0;
   }
   > .alignfull:where(:not(.has-global-padding))
-    > :where([class*='wp-block-']:not(.alignfull):not([class*='__']), p, h1, h2, h3, h4, h5, h6, ul, ol) {
+    > :where(
+      [class*='wp-block-']:not(.alignfull):not([class*='__']),
+      p,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      ul,
+      ol
+    ) {
     padding-right: var(--wp--style--root--padding-right);
     padding-left: var(--wp--style--root--padding-left);
   }
   :where(.has-global-padding)
     > .alignfull:where(:not(.has-global-padding))
-    > :where([class*='wp-block-']:not(.alignfull):not([class*='__']), p, h1, h2, h3, h4, h5, h6, ul, ol) {
+    > :where(
+      [class*='wp-block-']:not(.alignfull):not([class*='__']),
+      p,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      ul,
+      ol
+    ) {
     padding-right: 0;
     padding-left: 0;
   }
@@ -80,6 +102,7 @@ body {
   }
   .is-layout-flex {
     gap: 1.5rem;
+    @extend .column-flexGapFix;
   }
   .is-layout-flow > .alignleft {
     float: left;

--- a/src/scss/framework/components/_cards.scss
+++ b/src/scss/framework/components/_cards.scss
@@ -331,7 +331,6 @@ used on utk.edu home specifically */
   // border-radius: 0 0 30px 0;
   // border-radius is being overwritten below. We might use this instead of the angle in WDS?
   // height: 100%;   // breaks equal height cards. no good.
-
   @extend .card-flexGapFix;
 }
 
@@ -421,6 +420,10 @@ used on utk.edu home specifically */
   flex-direction: column;
   @media screen and (min-width: 550px) {
     flex-direction: row;
+    @supports (-webkit-touch-callout: none) and (not (translate: none)) {
+      /* makes sure cards aren't having padding added by fix */
+      margin-right: 0 !important;
+    }
   }
 }
 .bioCard {
@@ -553,12 +556,14 @@ used on utk.edu home specifically */
   align-content: stretch;
   background-color: #fafafa;
   background-color: $utgray1;
+
   // border-radius: 0 0 30px 0;
   // border-radius is being overwritten with clip corner – might use rounded in WDS instead?
   // height: 100%; // breaks equal height cards. no good.
 
   // border-radius: 0 0 30px 0;
-  @extend .card-flexGapFix;
+  @extend .card-flexGapFix; /* fix for gap in older safari ios */
+
   @media screen and (min-width: 800px) {
     flex-basis: 46%;
     flex-basis: calc((98% - 3rem) / 2);
@@ -569,7 +574,7 @@ used on utk.edu home specifically */
     font-size: calc($h2-font-size * 0.6);
   }
   h3 {
-    font-size: calc($h3-font-size * 0.6);
+    font-size: calc($h3-font-size * 0.8);
   }
   p + .wp-block-buttons {
     margin: calc($spacer * 3) 0 calc($spacer * 1);

--- a/src/scss/framework/components/_spacer.scss
+++ b/src/scss/framework/components/_spacer.scss
@@ -1,0 +1,32 @@
+.spacer-responsive-lg {
+  height: 2vw !important;
+
+  @media screen and (min-width: 800px) {
+    height: 3vw !important;
+  }
+  @media screen and (min-width: 1200px) {
+    height: 5vw !important;
+  }
+}
+
+.spacer-responsive-md {
+  height: 1vw !important;
+
+  @media screen and (min-width: 800px) {
+    height: 1.5vw !important;
+  }
+  @media screen and (min-width: 1200px) {
+    height: 3.5 !important;
+  }
+}
+
+.spacer-responsive-sm {
+  height: 0.5vw !important;
+
+  @media screen and (min-width: 800px) {
+    height: 0.75vw !important;
+  }
+  @media screen and (min-width: 1200px) {
+    height: 2.5vw !important;
+  }
+}

--- a/src/scss/framework/styles/_buttons.scss
+++ b/src/scss/framework/styles/_buttons.scss
@@ -250,9 +250,11 @@
 //     }
 //   }
 // }
+
 .wp-block-buttons {
   @extend .buttons-flexGapFix;
 }
+
 .wp-block-button > * {
   padding: 0.6em 1.3em !important;
   color: $utlinkriver;

--- a/src/scss/framework/styles/_fixes.scss
+++ b/src/scss/framework/styles/_fixes.scss
@@ -3,25 +3,49 @@ FIXES
 Fixes aimed at certain browsers or os versions
 – – - – - */
 
+/* - - - - 
+ 
+- - - - - */
+
+.hardware-excelerated {
+  /* force style to be rendered by the gpu. 
+  Implemented to mainly fix filter:drop-shadow issues where drop shadow of .framedOrangeShadow not rendering consistently */
+  -webkit-transform: translate3d(0, 0, 0);
+  -moz-transform: translate3d(0, 0, 0);
+  -ms-transform: translate3d(0, 0, 0);
+  -o-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+}
 /* – – – - -
 iPad ios 14.4 and earlier
 – – - – - */
+
+.column-flexGapFix {
+  @supports (-webkit-touch-callout: none) and (not (translate: none)) {
+    & *:not(:last-child) {
+      margin-right: clamp(calc($spacer * 1.5), 2%, calc($spacer * 3));
+    }
+  }
+}
 
 .card-flexGapFix {
   @supports (-webkit-touch-callout: none) and (not (translate: none)) {
     margin-bottom: clamp(calc($spacer * 1.5), 5%, calc($spacer * 3)) !important;
     &:not(:last-child) {
-      margin-right: 5%;
-      margin-right: clamp(calc($spacer * 1.5), 5%, calc($spacer * 3));
+      margin-right: clamp(calc($spacer * 1.3), 5%, calc($spacer * 3));
     }
   }
 }
 
+/* 
+buttons-flexGapFix was created before the column-flexGapFix. 
+The column-flexGapFix replaces the need for this since wordpress puts buttons inside columns when grouped.
+*/
 .buttons-flexGapFix {
   /* should only be applied to buttons that are sub of the block-buttons parent */
   @supports (-webkit-touch-callout: none) and (not (translate: none)) {
     & * {
-      margin-right: clamp($spacer, calc($spacer * 1.3), calc($spacer * 3));
+      // margin-right: clamp($spacer, calc($spacer * 1.3), calc($spacer * 3)); /* no longer needed. fixed with is-layout-flex has a column gap fix applied. */
       margin-bottom: clamp($spacer, calc($spacer * 1.3), calc($spacer * 3));
     }
   }

--- a/src/scss/framework/styles/_fixes.scss
+++ b/src/scss/framework/styles/_fixes.scss
@@ -21,6 +21,7 @@ iPad ios 14.4 and earlier
 – – - – - */
 
 .column-flexGapFix {
+  /* does this need a new name – since this fixes flex items, not just columns */
   @supports (-webkit-touch-callout: none) and (not (translate: none)) {
     & *:not(:last-child) {
       margin-right: clamp(calc($spacer * 1.5), 2%, calc($spacer * 3));

--- a/src/scss/framework/styles/_frame.scss
+++ b/src/scss/framework/styles/_frame.scss
@@ -227,6 +227,8 @@ outline-offset: calc(-1 * ($spacer / 2));
 
 .framedOrangeShadow {
   filter: drop-shadow(1.25rem 1.25rem 0px $utorange);
+  @extend .hardware-excelerated;
+
   margin: 1rem;
   .wp-element-caption {
     // filter: drop-shadow(0px 0px 0px rgba(255, 255, 255, 0.5)) !important;

--- a/src/scss/framework/styles/_patterns.scss
+++ b/src/scss/framework/styles/_patterns.scss
@@ -130,6 +130,9 @@
     }
   }
   .twoUp-gallery-img-lg {
+    &.alignright {
+      margin-inline-start: 0; /* makes inner image not have a start margin */
+    }
     img {
       max-width: 100%;
       margin-right: 0;

--- a/src/scss/framework/styles/_patterns.scss
+++ b/src/scss/framework/styles/_patterns.scss
@@ -92,26 +92,64 @@
 .twoUp-gallery {
   margin: 0 auto;
   // border: 2px solid red;
-  max-width: 1854px;
+  max-width: 1732px;
   padding: 0;
   & .is-layout-flow > .alignleft {
     margin-inline-end: 0;
   }
+  // .wp-block-columns {
+  //   // margin-bottom: -5rem;
+  //   @include media-breakpoint-up(md) {
+  //     margin-bottom: 0;
+  //   }
+  // }
+  .wp-block-columns {
+  }
+  .twoUp-gallery-img-sm {
+    display: block;
+    @include media-breakpoint-up(sm) {
+      margin-bottom: 0;
+      -webkit-margin-start: 0;
+      margin-inline-start: 0;
+    }
+    &.alignright {
+      margin-inline-start: 0; /* makes inner image not have a start margin */
+    }
+    img {
+      // margin-bottom: 5rem;
+      max-width: 80vw;
+      margin-right: clamp(1.5vw, 2rem, 3vw);
+      margin-bottom: 0;
+      @include media-breakpoint-up(md) {
+        margin-right: 0;
+        max-width: 100%;
+
+        margin-bottom: clamp(1vw, 3rem, 4.5vw);
+        margin-bottom: clamp(2vw, 4rem, 5vw);
+      }
+    }
+  }
+  .twoUp-gallery-img-lg {
+    img {
+      max-width: 100%;
+      margin-right: 0;
+    }
+  }
 }
 
 // Two up Gallery (large first) Forces image to overlap with orange bar on mobile. Grounds the image.
-.twoUp-gallery-lgsm figure:first-of-type {
-  margin-bottom: -5rem;
-  @media screen and (min-width: 700px) {
-    margin-bottom: 0;
-  }
-}
-.twoUp-gallery-smlg figure:first-of-type {
-  // margin-bottom: -5rem;
-  @media screen and (min-width: 700px) {
-    margin-bottom: 0;
-  }
-}
+// .twoUp-gallery-lgsm figure:first-of-type {
+//   margin-bottom: -5rem;
+//   @media screen and (min-width: 700px) {
+//     margin-bottom: 0;
+//   }
+// }
+// .twoUp-gallery-smlg figure:first-of-type {
+//   // margin-bottom: -5rem;
+//   @media screen and (min-width: 700px) {
+//     margin-bottom: 0;
+//   }
+// }
 
 // .colA {
 //   border: 1px solid green;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -148,6 +148,7 @@
 @import './framework/components/profiles';
 @import './framework/components/promos';
 @import './framework/components/sliders';
+@import './framework/components/spacer';
 @import './framework/components/strip';
 
 // ------  UT Styles – LOCAL


### PR DESCRIPTION
fix twoUp-Gallery responsiveness (small/large full width off-center image gallery pattern)
– adjust spacing with css after removing WP spacer block from pattern 
– add controls for small and large images to better control vertical spacing
– fix pattern not centering properly at certain sizes
– tweak alignment of small image on mobile to have better pattern flow on smaller devices

Adjust card h2 and h3
– increase card headers sizing on mobile by increasing the multiplier to keep headers from being smaller than body

Fixes for render errors on certain older iPad and Iphone iOS versions
– fix render issues on older browsers not supporting flex gap (row and columns) by replacing with margins on specific devices
– fix orange frame (drop-shadow) inconsistent render by forcing gpu render of class.

Responsive Spacers
– add new styling controls for WP spacer block to make spacing relative to device size. These are still experimental and will be continued to be tweaked and hopefully added to plugin for easier use.