### PR TITLE
fix(slate): update styles to resolve slate display issues

### DIFF
--- a/src/components/SlateModalTabs.tsx
+++ b/src/components/SlateModalTabs.tsx
@@ -38,16 +38,31 @@ function SlateFormReplace({ commentString }: Props): JSX.Element {
   const [slateButtonStyle, setSlateButtonStyle] = useState('');
   const [modalOpacity, setModalOpacity] = useState(0);
 
+  const modalRef = useRef<HTMLDivElement>(null);
+
   const handleCloseModal = () => {
-    // Fade out with opacity before hiding
+    // Re-enabling .framedOrangeShadow class
+    if (modalRef?.current) {
+      const modalParent = modalRef.current.parentElement;
+      modalParent?.classList.replace(
+        'framedOrangeShadowDisabled',
+        'framedOrangeShadow'
+      );
+    }
     setModalOpacity(0);
-    setTimeout(() => {
-      setShowModal(false);
-    }, 220);
+    setShowModal(false);
     // Re-enable <html> scrolling
     document.documentElement.style.removeProperty('overflow-y');
   };
   const handleShowModal = () => {
+    // Disabling .framedOrangeShadow class because transforms prevent fixed position modal from displaying correctly
+    if (modalRef?.current) {
+      const modalParent = modalRef.current.parentElement;
+      modalParent?.classList.replace(
+        'framedOrangeShadow',
+        'framedOrangeShadowDisabled'
+      );
+    }
     // Show, then fade in with opacity
     setShowModal(true);
     setTimeout(() => {
@@ -125,6 +140,7 @@ function SlateFormReplace({ commentString }: Props): JSX.Element {
           opacity: modalOpacity,
         }}
         className={`${styles['slate-modal-container']}`}
+        ref={modalRef}
       >
         <div
           className={styles['slate-modal-backdrop']}

--- a/src/scss/components/SlateForm.module.scss
+++ b/src/scss/components/SlateForm.module.scss
@@ -7,6 +7,7 @@
   top: 0;
   left: 0;
   width: 100vw;
+  max-width: 100vw !important;
   height: 100vh;
   z-index: 1040;
   transition: all 0.22s;

--- a/src/scss/framework/styles/_fixes.scss
+++ b/src/scss/framework/styles/_fixes.scss
@@ -51,3 +51,8 @@ The column-flexGapFix replaces the need for this since wordpress puts buttons in
     }
   }
 }
+
+// Fixes the issue of navigation appearing above modal if inside a div with class .wp-block-cover__inner-container
+.wp-block-cover__inner-container {
+  z-index: 1000 !important;
+}


### PR DESCRIPTION
Resolves display issues when adding slate modal tabs inside div with framedOrangeShadow class. This and potentially other classes with css transforms prevent position: fixed modal from overlaying the entire page.