### PR TITLE
tweak smallest screens for iphone 13 mini 

### DIFF
--- a/src/scss/framework/components/_pills.scss
+++ b/src/scss/framework/components/_pills.scss
@@ -11,6 +11,7 @@
 
   @media screen and (max-width: 410px) {
     margin-bottom: 0px;
+    margin-right: 0.2rem;
   }
 }
 .nav-pills {
@@ -20,6 +21,10 @@
   @media screen and (max-width: 410px) {
     //     font-size: calc($p-font-size * 0.8);
     font-size: calc($p-font-size * 0.7);
+
+    & :last-child .nav-link {
+      margin-right: 0 !important;
+    }
   }
 }
 .nav-pills .nav-link.active {
@@ -34,13 +39,16 @@
   // box-shadow: 0.25rem -0.2rem 0.05rem $utgray3;
   // box-shadow: 0.1rem -0.2rem 0 $utgray2;
   border-radius: 0.45rem 0.45rem 0 0;
-  margin-bottom: -1px;
+  margin-bottom: -2px;
   // border: 1px solid #b3b3b3;
   // border-bottom: 1px solid $utgray2;
   // box-shadow: 0.05rem -2px 0 $utgray3;
+
   @media screen and (max-width: 410px) {
     padding-top: 0.7rem;
-    margin-bottom: -1.2px;
+    // padding-left: 0.4rem;
+    // padding-right: 0.4rem;
+    margin-bottom: -2px;
     font-size: 115%;
   }
 }
@@ -67,32 +75,35 @@ button.form_button_submit:focus {
   box-shadow: 0 0 0 0.25rem rgba(88, 89, 91, 0.25);
 }
 
-// // switching to buttons at the smallest of screens. Killed for now. have reduced type size above to fix tabs.
-// // This will break for WDS
-// @media screen and (max-width: 380px) {
-//   .nav-pills .nav-link {
-//     border-radius: 0.45rem 0.45rem 0.45rem 0.45rem;
-//     margin-bottom: 10px;
-//     background: #f6f6f6;
-//     border: 1px solid #b3b3b3;
-//     justify-content: flex-start;
-//   }
+// switching to buttons at the smallest of screens. Killed for now. have reduced type size above to fix tabs.
+// This will break for WDS
+@media screen and (max-width: 374px) {
+  .nav-pills .nav-link {
+    border-radius: 0.45rem 0.45rem 0.45rem 0.45rem;
+    margin-bottom: 10px;
+    background: #f6f6f6;
 
-//   .nav-pills .nav-link.active {
-//     // background-color: #1a73c5 !important;
-//     // background-color: $utlinkhover !important;
-//     // color: white !important;
+    background-color: #e5e5e5;
+    border: 1px solid #b3b3b3;
+    justify-content: flex-start;
+  }
 
-//     background: #f6f6f6;
-//     font-size: 100%;
-//     border: none;
-//     border-radius: 0.45rem 0.45rem 0.45rem 0.45rem;
-//     border: 1px solid #b3b3b3;
-//     margin-bottom: 10px;
-//   }
-//   .nav-pills {
-//     font-size: calc($p-font-size * 0.8);
-//     display: flex;
-//     align-items: flex-start;
-//   }
-// }
+  .nav-pills .nav-link.active {
+    // background-color: #1a73c5 !important;
+    // background-color: $utlinkhover !important;
+    // color: white !important;
+
+    background: #f6f6f6;
+    font-size: 100%;
+    border: none;
+    border-radius: 0.45rem 0.45rem 0.45rem 0.45rem;
+    border: 1px solid #b3b3b3;
+    margin-bottom: 10px;
+    padding-top: 0.5rem;
+  }
+  .nav-pills {
+    font-size: calc($p-font-size * 0.8);
+    display: flex;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
– reduce x padding slighting in active tab
– reduce margin between tabs slightly
– remove last-childs margin to give more space
– add fallback button styling for the smallest of small screens that remains consistent with tab feel
