### PR TITLE
fix medium breakpoint for media-text utilizing third of space

### DIFF
--- a/src/scss/framework/styles/_patterns.scss
+++ b/src/scss/framework/styles/_patterns.scss
@@ -622,3 +622,14 @@
     }
   }
 }
+
+// use this when you need media-text block to have an earlier breakpoint due to smaller photo width. Created for 33%
+.media-text-33-stack-early {
+  @media screen and (max-width: 950px) {
+    grid-template-columns: 100% !important;
+    .wp-block-media-text__content {
+      grid-column: 1 !important;
+      grid-row: 2 !important;
+    }
+  }
+}


### PR DESCRIPTION
– add a class to force media-text block using 33% width to break earlier at medium widths