### PR TITLE
mobile tweaks for cover images

### DIFF
--- a/src/scss/framework/components/_cards.scss
+++ b/src/scss/framework/components/_cards.scss
@@ -280,6 +280,18 @@ used on utk.edu home specifically */
     }
   }
 }
+
+.full-width-card {
+  &.push-card-down {
+    // this is used specifically on visit textural video.
+    // The class of .push-down was also manipulating the box positioning on home.
+    margin-top: 70vh;
+    @media screen and (min-width: 800px) {
+      margin-top: 0;
+    }
+  }
+}
+
 /* - - - - - - - - - - - - */
 /* profileCard */
 /* - - - - - - - - - - - - */

--- a/src/scss/framework/components/_cover.scss
+++ b/src/scss/framework/components/_cover.scss
@@ -38,3 +38,20 @@
   display: block;
   position: relative;
 }
+
+@media screen and (max-width: 1190px) {
+  .wp-block-cover.cover-mobile-thin {
+    // add on to control the height of a cover. WordPress does not scale this well automatically. forcing height to be smaller on smaller screens.
+    height: 30vw !important;
+    min-height: auto;
+  }
+  .wp-block-cover.cover-mobile-thin img,
+  .wp-block-cover.cover-mobile-thin span {
+  }
+}
+@supports (-webkit-touch-callout: none) {
+  .fix-ios-cover-mobile {
+    background-attachment: scroll !important;
+    background-size: auto 100%;
+  }
+}


### PR DESCRIPTION
– add vertical scale to cover image to fix WordPress lack of responsiveness for height at mobile sizes
– add style to increase height of image behind text box